### PR TITLE
Update launch configuration and test scripts for marcos-aws

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,10 +16,10 @@
 			"runtimeExecutable": "npx", // Use npx to run tsx
 			"args": [
 				"tsx", // Command to run
-				"${workspaceFolder}/apps/aws/test/test-optimize-images.ts" // Script to execute with tsx
+				"${workspaceFolder}/apps/marcos-aws/test/test-optimize-images.ts" // Script to execute with tsx
 			],
-			"cwd": "${workspaceFolder}/apps/aws", // Set working directory to load .env correctly
-			"envFile": "${workspaceFolder}/apps/aws/.env", // Load environment variables
+			"cwd": "${workspaceFolder}/apps/marcos-aws", // Set working directory to load .env correctly
+			"envFile": "${workspaceFolder}/apps/marcos-aws/.env", // Load environment variables
 			"console": "integratedTerminal",
 			"internalConsoleOptions": "neverOpen",
 			"skipFiles": [
@@ -38,10 +38,10 @@
 			"runtimeExecutable": "npx", // Use npx to run tsx
 			"args": [
 				"tsx", // Command to run
-				"${workspaceFolder}/apps/aws/test/test-optimize-storage.ts" // Script to execute with tsx
+				"${workspaceFolder}/apps/marcos-aws/test/test-optimize-storage.ts" // Script to execute with tsx
 			],
-			"cwd": "${workspaceFolder}/apps/aws", // Set working directory to load .env correctly
-			"envFile": "${workspaceFolder}/apps/aws/.env", // Load environment variables
+			"cwd": "${workspaceFolder}/apps/marcos-aws", // Set working directory to load .env correctly
+			"envFile": "${workspaceFolder}/apps/marcos-aws/.env", // Load environment variables
 			"console": "integratedTerminal",
 			"internalConsoleOptions": "neverOpen",
 			"skipFiles": [

--- a/apps/marcos-aws/test/test-optimize-images.ts
+++ b/apps/marcos-aws/test/test-optimize-images.ts
@@ -31,7 +31,7 @@ const mockEvent: S3CreateEvent = {
 					arn: `arn:aws:s3:::${process.env.FILES_BUCKET || 'your_local_or_dev_bucket_name'}`
 				},
 				object: {
-					key: '3d71bcf9-c1b7-44a4-abca-913e220bc8d1/photo/3bfdd2e1-daf3-4897-be17-c1b046bf2ba3.jpeg',
+					key: 'abf2237b-268c-41bb-9f28-b09c601a064f/photo/9f812938-b843-40e6-a202-bf5acb5fa85b.png',
 					size: 1024,
 					eTag: '0123456789abcdef0123456789abcdef',
 					sequencer: '0A1B2C3D4E5F678901'

--- a/packages/balerial-s3/src/service/balerial-cloud-file.service.ts
+++ b/packages/balerial-s3/src/service/balerial-cloud-file.service.ts
@@ -14,6 +14,15 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { type AwsCredentialIdentity } from '@smithy/types';
 import type { Readable } from 'stream';
 
+interface S3ObjectHeaders {
+	contentType?: string;
+	contentLength?: number;
+	contentEncoding?: string;
+	contentLanguage?: string;
+	contentDisposition?: string;
+	metadata?: Record<string, string>;
+}
+
 export class BalerialCloudFileService {
 	private s3Client: S3Client;
 
@@ -44,9 +53,7 @@ export class BalerialCloudFileService {
 		});
 	}
 
-	public async getObjectHeaders(
-		key: string
-	): Promise<Record<string, string | number | Record<string, string>> | undefined> {
+	public async getObjectHeaders(key: string): Promise<S3ObjectHeaders | undefined> {
 		try {
 			const headResult = await this.s3Client.send(
 				new HeadObjectCommand({

--- a/packages/marcos-core/src/service/file.service.ts
+++ b/packages/marcos-core/src/service/file.service.ts
@@ -131,7 +131,7 @@ export class FileService {
 			return;
 		}
 
-		const originalFileContentType = originalFileHeaders.contentType as string | undefined;
+		const originalFileContentType = originalFileHeaders.contentType;
 
 		if (fileDto.optimizedKey == null) {
 			fileDto.optimizedKey = `optimized/${fileDto.key}${optimizationAndThumbnailTypeInfo?.optimizedExtension ?? ''}`;
@@ -155,7 +155,7 @@ export class FileService {
 		await this.repository.createFile(fileDto);
 
 		if (fileDto.optimizedKey != null) {
-			await this.balerialFileCloudService.tagFile(fileDto.optimizedKey, [FileService.expiryTag]);
+			await this.balerialFileCloudService.tagFile(fileDto.key, [FileService.expiryTag]);
 		}
 	}
 


### PR DESCRIPTION
- Changed paths in `.vscode/launch.json` to point to `marcos-aws` instead of `aws` for test scripts.
- Modified `balerial-cloud-file.service.ts` to return a more specific type for object headers.
- Adjusted `file.service.ts` to correctly tag files using the original key instead of the optimized key.